### PR TITLE
Fix byte-compilation error

### DIFF
--- a/hideshow-org.el
+++ b/hideshow-org.el
@@ -77,14 +77,8 @@
 (defvar hs-org/trigger-keys-all (list [S-tab] [S-iso-lefttab] [(shift tab)] [backtab])
   "The keys to bind to toggle all block visibility.")
 
-(defvar hs-org/minor-mode-map nil
-  "The keymap of hs-org/minor-mode")
-
 (defvar hs-org/started-hideshow-p nil
   "Did I start hideshow when my minor mode was invoked?")
-
-(unless hs-org/minor-mode-map
-  (setq hs-org/minor-mode-map (make-sparse-keymap)))
 
 (defvar hs-org/hide-show-all-next nil
   "Keeps the state of how the buffer was last toggled by Shift TABing.")
@@ -118,12 +112,14 @@ When hs-org minor mode is enabled, the TAB key toggles the
 visible state of the code, and shift TAB toggles the visible
 state of the entire file.
 
-You can customize the key through `hs-org/trigger-key-block'."
+You can customize the key through `hs-org/trigger-key-block'.
+\\{hs-org/minor-mode-map}"
   ;; The initial value.
   nil
   ;; The indicator for the mode line.  Nothing.  hs will already be in there.
   ""
   :group 'editing
+  :keymap (make-sparse-keymap)
   
   (hs-org/define-keys)
   ;; We want hs-minor-mode on when hs-org/minor-mode is on.

--- a/hideshow-org.el
+++ b/hideshow-org.el
@@ -91,16 +91,15 @@
                hs-org/started-hideshow-p))
   (make-variable-buffer-local var))
 
-(defmacro hs-org/define-keys ()
-  `(progn 
-     ,@(mapcar (lambda (key) `(hs-org/define-key ,key hs-org/hideshow)) hs-org/trigger-keys-block)
-     ,@(mapcar (lambda (key) `(hs-org/define-key ,key hs-org/hideshow-all)) hs-org/trigger-keys-all)
-     ))
-
 ;; No closures is killing me!
-(defmacro hs-org/define-key (key function)
-  `(define-key hs-org/minor-mode-map ,key (lambda () (interactive)
-                                                  (,function ,key))))
+(defun hs-org/define-key (map key function)
+  (define-key map key `(lambda () (interactive) (,function ,key))))
+
+(defun hs-org/make-keymap ()
+  (let ((map (make-sparse-keymap)))
+    (mapc (lambda (key) (hs-org/define-key map key 'hs-org/hideshow)) hs-org/trigger-keys-block)
+    (mapc (lambda (key) (hs-org/define-key map key 'hs-org/hideshow-all)) hs-org/trigger-keys-all)
+    map))
 
 (define-minor-mode hs-org/minor-mode
     "Toggle hs-org minor mode.
@@ -113,15 +112,12 @@ visible state of the code, and shift TAB toggles the visible
 state of the entire file.
 
 You can customize the key through `hs-org/trigger-key-block'.
+
 \\{hs-org/minor-mode-map}"
-  ;; The initial value.
-  nil
-  ;; The indicator for the mode line.  Nothing.  hs will already be in there.
-  ""
+  :lighter ""				; Nothing.  hs will already be in there.
+  :keymap (hs-org/make-keymap)
   :group 'editing
-  :keymap (make-sparse-keymap)
   
-  (hs-org/define-keys)
   ;; We want hs-minor-mode on when hs-org/minor-mode is on.
   (if hs-org/minor-mode
       ;; hs-org/minor-mode was turned on.


### PR DESCRIPTION
@shanecelis, are you still maintaining this package?

I was trying to re-install this from MELPA (the recipe was submitted by @yasuyk), but it throws a byte compilation error:

```
hideshow-org.el:112:1:Error: Symbol's value as variable is void: hs-org/trigger-keys-block
```

`hideshow-org.el` loads fine; it just can't be byte-compiled from a "cold" start because `defvar` does not bind variables at compile time, and the variables `hs-org/trigger-keys-block` and `hs-org/trigger-keys-all` are required for the expansion of the macro `hs-org/define-keys`. 

This PR is one way of fixing the issue: the keymap for the minor mode is defined at load time, rather than compile time. I've tested this on my machine and it byte compiles without error.
